### PR TITLE
PHP 8.5, WordPress 6.9, Bedrock 1.28.4

### DIFF
--- a/.devcontainer/compose.wpstemplate.yaml
+++ b/.devcontainer/compose.wpstemplate.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/kodansha/bedrock:php8.4-fpm
+    image: ghcr.io/kodansha/bedrock:php8.5-fpm
     init: true
     volumes:
       - ..:/workspaces/{{project_name}}:cached

--- a/cms/composer.wpstemplate.json
+++ b/cms/composer.wpstemplate.json
@@ -11,6 +11,7 @@
   ],
   "repositories": [
     {
+      "name" : "wpackagist",
       "type": "composer",
       "url": "https://wpackagist.org",
       "only": [
@@ -29,20 +30,19 @@
     }
   ],
   "require": {
-    "php": "~8.4.0",
+    "php": "~8.5.0",
     "composer/installers": "^2.2",
     "vlucas/phpdotenv": "^5.5",
     "oscarotero/env": "^2.1",
     "roots/bedrock-autoloader": "^1.0",
     "roots/bedrock-disallow-indexing": "^2.0",
-    "roots/wordpress": "6.8.3",
+    "roots/wordpress": "6.9",
     "roots/wp-config": "1.0.0",
-    "koodimonni-language/ja": "6.8.3",
+    "koodimonni-language/ja": "6.9",
     "wpackagist-plugin/wp-multibyte-patch": "2.9.2"
   },
   "require-dev": {
-    "laravel/pint": "^1.18",
-    "roave/security-advisories": "dev-latest"
+    "laravel/pint": "^1.18"
   },
   "config": {
     "optimize-autoloader": true,


### PR DESCRIPTION
This pull request updates the development environment and dependencies to use PHP 8.5 and WordPress 6.9. The changes ensure compatibility with the latest versions and streamline the composer configuration.

**Environment updates:**

* Updated the Docker image in `.devcontainer/compose.wpstemplate.yaml` to use `php8.5-fpm` instead of `php8.4-fpm`.

**Dependency and configuration updates:**

* Changed the required PHP version in `cms/composer.wpstemplate.json` from `~8.4.0` to `~8.5.0`.
* Updated `roots/wordpress` and `koodimonni-language/ja` dependencies to version `6.9`.
* Added the `wpackagist` repository entry to the composer configuration.
* Removed the `roave/security-advisories` package from `require-dev` in composer configuration.