### PR TITLE
feat: add WordPress Multisite configuration support

### DIFF
--- a/.devcontainer/config/web/default.wpstemplate.conf
+++ b/.devcontainer/config/web/default.wpstemplate.conf
@@ -51,6 +51,22 @@ server {
         return 405;
     }
 
+    # WordPress multisite configuration
+    # https://roots.io/bedrock/docs/server-configuration/
+    #
+    # Subdomain multisite rewrites
+    # Uncomment the following lines if using WordPress multisite in subdomain mode
+    # rewrite ^/(wp-.*.php)$ /wp/$1 last;
+    # rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
+    #
+    # Subfolder multisite rewrites
+    # Uncomment the following lines if using WordPress multisite in subfolder mode
+    # if (!-e $request_filename) {
+    #   rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+    #   rewrite ^(/[^/]+)?(/wp-.*) /wp$2 last;
+    #   rewrite ^(/[^/]+)?(/.*.php) /wp$2 last;
+    # }
+
     # Main routing (WordPress permalink processing)
     location / {
         try_files $uri $uri/ /index.php$is_args$args;

--- a/cms/config/application.php
+++ b/cms/config/application.php
@@ -157,6 +157,18 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
     $_SERVER['HTTPS'] = 'on';
 }
 
+/**
+ * Enable WordPress Multisite
+ * Uncomment and modify the following lines to enable multisite functionality
+ */
+// Config::define('WP_ALLOW_MULTISITE', true);
+// Config::define('MULTISITE', true);
+// Config::define('SUBDOMAIN_INSTALL', true);
+// Config::define('DOMAIN_CURRENT_SITE', parse_url(env('WP_HOME'), PHP_URL_HOST));
+// Config::define('PATH_CURRENT_SITE', '/');
+// Config::define('SITE_ID_CURRENT_SITE', 1);
+// Config::define('BLOG_ID_CURRENT_SITE', 1);
+
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 
 if (file_exists($env_config)) {


### PR DESCRIPTION
Add commented-out configuration for WordPress Multisite in both Nginx and application config:

- Add Nginx rewrite rules for subdomain and subfolder multisite modes
- Add WordPress Multisite constants (WP_ALLOW_MULTISITE, MULTISITE, etc.) to application.php
- Include CSP frame-ancestors header alongside X-Frame-Options for enhanced security
- All multisite settings are commented out by default and can be enabled as needed