### PR TITLE
Fix whitespace in nginx server_name directive

### DIFF
--- a/.devcontainer/config/web/default.wpstemplate.conf
+++ b/.devcontainer/config/web/default.wpstemplate.conf
@@ -3,7 +3,7 @@
 
 server {
     listen 80;
-    server_name  _;
+    server_name _;
     root /workspaces/{{project_name}}/cms/web;
     index index.php;
 


### PR DESCRIPTION
Correct whitespace formatting in the nginx configuration for the server_name directive.