### PR TITLE
Refactor Nginx configuration by removing unused proxy headers

### DIFF
--- a/.devcontainer/config/web/default.wpstemplate.conf
+++ b/.devcontainer/config/web/default.wpstemplate.conf
@@ -38,14 +38,6 @@ server {
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 
-    # Proxy headers (for passing client information to backend)
-    # Pass the original Host header from the client request
-    proxy_set_header Host $host;
-    # Pass the real client IP address
-    proxy_set_header X-Real-IP $remote_addr;
-    # Append client IP to the chain of proxy addresses
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
     # Reject requests with unsupported HTTP method
     if ($request_method !~ ^(GET|POST|HEAD|OPTIONS|PUT|DELETE)$) {
         return 405;


### PR DESCRIPTION
Remove unused proxy header settings from the Nginx configuration to streamline the setup.