### PR TITLE
Refactor Nginx configuration to remove unused PATH_INFO parameter

### DIFF
--- a/.devcontainer/config/web/default.wpstemplate.conf
+++ b/.devcontainer/config/web/default.wpstemplate.conf
@@ -129,7 +129,6 @@ server {
         fastcgi_pass app:9000;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_script_name;
     }
 
     # Allow PHP execution for WordPress core files (in /wp/ directory)
@@ -137,7 +136,6 @@ server {
     location ~ ^/wp/.*\.php$ {
         fastcgi_pass app:9000;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_script_name;
         include fastcgi_params;
     }
 


### PR DESCRIPTION
Eliminate the unused PATH_INFO parameter from FastCGI settings in the Nginx configuration to streamline the setup.