### PR TITLE
feat: update WordPress 7.0 and adjust dependency version constraints

### DIFF
--- a/cms/composer.wpstemplate.json
+++ b/cms/composer.wpstemplate.json
@@ -13,11 +13,7 @@
     {
       "name": "wp-packages",
       "type": "composer",
-      "url": "https://repo.wp-packages.org",
-      "only": [
-        "wp-plugin/*",
-        "wp-theme/*"
-      ]
+      "url": "https://repo.wp-packages.org"
     },
     {
       "type": "composer",
@@ -31,18 +27,18 @@
   ],
   "require": {
     "php": "~8.5.0",
-    "composer/installers": "^2.2",
-    "oscarotero/env": "^2.1",
+    "composer/installers": "^2.0",
+    "oscarotero/env": "^2.0",
     "roots/bedrock-autoloader": "^1.0",
     "roots/bedrock-disallow-indexing": "^2.0",
-    "roots/wordpress": "6.9.4",
-    "roots/wp-config": "1.0.0",
+    "roots/wordpress": "7.0",
+    "roots/wp-config": "^1.0",
     "vlucas/phpdotenv": "^5.5",
-    "koodimonni-language/ja": "6.9.4",
+    "koodimonni-language/ja": "7.0",
     "wp-plugin/wp-multibyte-patch": "2.9.3"
   },
   "require-dev": {
-    "laravel/pint": "^1.27",
+    "laravel/pint": "^1.0",
     "pestphp/pest": "^4.0"
   },
   "config": {

--- a/scripts/check-bedrock-changes.sh
+++ b/scripts/check-bedrock-changes.sh
@@ -19,7 +19,7 @@ pushd bedrock >/dev/null 2>&1
 git pull
 
 # Get the most recent Bedrock tag
-original_bedrock_tag=`git describe --tags --abbrev=0`
+original_bedrock_tag=$(git describe --tags --abbrev=0)
 
 echo "========================================================================="
 echo $wp_starter_bedrock_tag : The most recent wp-starter tag
@@ -27,4 +27,5 @@ echo ↓
 echo $original_bedrock_tag : The most recent Bedrock tag
 echo "========================================================================="
 
-git difftool -d ${wp_starter_bedrock_tag} ${original_bedrock_tag}
+# git difftool -d ${wp_starter_bedrock_tag} ${original_bedrock_tag}
+git diffa ${wp_starter_bedrock_tag} ${original_bedrock_tag}


### PR DESCRIPTION
## Summary

- Update `roots/wordpress` from `6.9.4` to `7.0`
- Update `koodimonni-language/ja` from `6.9.4` to `7.0`
- Relax version constraints for `composer/installers`, `oscarotero/env`, `roots/wp-config`, and `laravel/pint`
- Remove `only` filter from `wp-packages` repository config

## Test plan

- [ ] Run `composer install` in the `cms` directory and confirm no errors
- [ ] Verify WordPress 7.0 boots correctly in the local environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)