### PR TITLE
WordPress 7.1, Bedrock 1.31.4

### DIFF
--- a/cms/composer.wpstemplate.json
+++ b/cms/composer.wpstemplate.json
@@ -31,10 +31,10 @@
     "oscarotero/env": "^2.0",
     "roots/bedrock-autoloader": "^1.0",
     "roots/bedrock-disallow-indexing": "^2.0",
-    "roots/wordpress": "7.0.4",
+    "roots/wordpress": "7.1",
     "roots/wp-config": "^1.0",
     "vlucas/phpdotenv": "^5.5",
-    "koodimonni-language/ja": "7.0.4",
+    "koodimonni-language/ja": "7.1",
     "wp-plugin/wp-multibyte-patch": "2.9.3"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary
- Bump `roots/wordpress` and `koodimonni-language/ja` from 7.0.4 to 7.1 in `cms/composer.wpstemplate.json` (Bedrock 1.31.4)

## Test plan
- [ ] Run `composer update` in a generated project and confirm WordPress 7.1 installs cleanly